### PR TITLE
Fixed: Get parameter uses an error method.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
@@ -130,7 +130,7 @@ public class SystemPropertiesServlet extends HttpServlet {
         final boolean oldEncrypt = JiveGlobals.isPropertyEncrypted(key);
         final String oldValueToLog = oldEncrypt ? "***********" : JiveGlobals.getProperty(key);
         final String value = request.getParameter("value");
-        final boolean encrypt = ParamUtils.getBooleanAttribute(request, "encrypt");
+        final boolean encrypt = ParamUtils.getBooleanParameter(request, "encrypt");
         final boolean alreadyExists = JiveGlobals.getProperty(key) != null;
         JiveGlobals.setProperty(key, value, encrypt);
         request.getSession().setAttribute("successMessage",


### PR DESCRIPTION
This param "encrypt" is in request form body, not in request attribute.